### PR TITLE
Add class for styling placeholder text

### DIFF
--- a/Dropdown.vue
+++ b/Dropdown.vue
@@ -5,7 +5,7 @@
           <span class="caret"></span>
         </li>
 
-        <li @click="toggleMenu()" class="dropdown-toggle placeholder" v-if="selectedOption.name === undefined">
+        <li @click="toggleMenu()" class="dropdown-toggle dropdown-toggle-placeholder" v-if="selectedOption.name === undefined">
           {{placeholderText}}
           <span class="caret"></span>
         </li>

--- a/Dropdown.vue
+++ b/Dropdown.vue
@@ -5,7 +5,7 @@
           <span class="caret"></span>
         </li>
 
-        <li @click="toggleMenu()" class="dropdown-toggle" v-if="selectedOption.name === undefined">
+        <li @click="toggleMenu()" class="dropdown-toggle placeholder" v-if="selectedOption.name === undefined">
           {{placeholderText}}
           <span class="caret"></span>
         </li>

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,8 @@ $ yarn add vue-dropdowns
 # Usage
 
 ```html
-<dropdown :options="arrayOfObjects" 
+<dropdown class="my-dropdown-toggle"
+          :options="arrayOfObjects" 
           :selected="object" 
           v-on:updateOption="methodToRunOnSelect" 
           :placeholder="'Select an Item'"
@@ -52,6 +53,22 @@ export default {
         }
       }
 </script>
+
+<style scoped>
+.my-dropdown-toggle {
+  border-radius: 5px;
+
+  ::v-deep .dropdown-toggle {
+    color: tomato;
+    font-size: 25px;
+    font-weight: 800;
+  }
+
+  ::v-deep .dropdown-toggle-placeholder {
+    color: #c4c4c4;
+  }
+}
+</style>
 
 ```
 


### PR DESCRIPTION
Class `placeholder` allows styling of placeholder text content, independent from styling of `.dropdown-toggle`

### Screenshots

**Current (Placeholder text style defaults to `.dropdown-toggle`)**

![Screen Shot 2020-09-16 at 00 58 19](https://user-images.githubusercontent.com/887849/93290894-20874300-f7b8-11ea-92b7-0aeae7696661.png)

**PR**
```
.dropdown-input

  // Override placeholder text colour
  >>> .placeholder
    color #C4C4C4
```
<img width="540" alt="Screen Shot 2020-09-16 at 00 58 34" src="https://user-images.githubusercontent.com/887849/93291005-604e2a80-f7b8-11ea-8104-cff6f6310088.png">

**... and dropdown list colour remains**

<img width="340" alt="Screen Shot 2020-09-16 at 00 59 34" src="https://user-images.githubusercontent.com/887849/93291122-a60af300-f7b8-11ea-91f9-1b916d7782af.png">

